### PR TITLE
Improve MSVC compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,12 @@ if(NOT hasParent)
     # flag (Visual C++ 2017 and later).
     if(MSVC)
         add_compile_options(/permissive-)
-    endif()
-    
+    else()
     # Add debugging options.
-    add_compile_options($<$<CONFIG:Debug>:-g3>)
-    add_compile_options($<$<CONFIG:Debug>:-ggdb>)
-    add_compile_options($<$<CONFIG:Debug>:-O0>)
+        add_compile_options($<$<CONFIG:Debug>:-g3>)
+        add_compile_options($<$<CONFIG:Debug>:-ggdb>)
+        add_compile_options($<$<CONFIG:Debug>:-O0>)
+    endif()
 
     # Set Warning flags
     if(MSVC)

--- a/include/cmdlp/line_parser.hpp
+++ b/include/cmdlp/line_parser.hpp
@@ -32,7 +32,7 @@ public:
     {
         token_list_t::const_iterator it = std::find(tokens.begin(), tokens.end(), option);
         if ((it != tokens.end()) && (++it != tokens.end())) {
-            if (!__starts_with(*it, "-")) {
+            if (!_starts_with(*it, "-")) {
                 return (*it);
             }
         }
@@ -78,7 +78,7 @@ private:
     /// @param n         specify the minimum number of characters to check.
     /// @return true  if the source starts with the prefix, give all the conditions.
     /// @return false if the source does not start with the prefix, give all the conditions.
-    static inline bool __starts_with(
+    static inline bool _starts_with(
         const std::string &source,
         const std::string &prefix,
         bool sensitive = false,

--- a/include/cmdlp/option.hpp
+++ b/include/cmdlp/option.hpp
@@ -28,7 +28,7 @@ public:
         // Nothing to do.
     }
 
-    virtual unsigned get_value_length() const = 0;
+    virtual std::size_t get_value_length() const = 0;
 
     virtual ~Option()
     {
@@ -56,7 +56,7 @@ public:
         // Nothing to do.
     }
 
-    virtual unsigned get_value_length() const
+    virtual std::size_t get_value_length() const
     {
         return 5;
     }
@@ -86,7 +86,7 @@ public:
         // Nothing to do.
     }
 
-    virtual unsigned get_value_length() const
+    virtual std::size_t get_value_length() const
     {
         return value.size();
     }

--- a/include/cmdlp/option_list.hpp
+++ b/include/cmdlp/option_list.hpp
@@ -139,17 +139,17 @@ public:
         return options.end();
     }
 
-    inline unsigned getLongestOption() const
+    inline std::size_t getLongestOption() const
     {
         return longest_option;
     }
 
-    inline unsigned getLongestValue() const
+    inline std::size_t getLongestValue() const
     {
         return longest_value;
     }
 
-    inline void updateLongestValue(unsigned length)
+    inline void updateLongestValue(std::size_t length)
     {
         if (length > longest_value)
             longest_value = length;
@@ -205,8 +205,8 @@ private:
     }
 
     option_list_t options;
-    unsigned longest_option;
-    unsigned longest_value;
+    std::size_t longest_option;
+    std::size_t longest_value;
 };
 
 template <>

--- a/test/test_cmdlp.cpp
+++ b/test/test_cmdlp.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
 
      dummy_argv.push_back((char *)"--verbose");
 
-    cmdlp::OptionParser parser(dummy_argv.size() - 1, dummy_argv.data());
+    cmdlp::OptionParser parser(static_cast<int>(dummy_argv.size() - 1), dummy_argv.data());
     parser.addOption('d', "--double", "Double value", 0.2);
     parser.addOption('i', "--int", "An integer value", 1);
     parser.addOption('s', "--string", "A string.. actually, a single word", "hello");

--- a/test/test_cmdlp.cpp
+++ b/test/test_cmdlp.cpp
@@ -12,22 +12,22 @@ void test_copy(cmdlp::OptionParser parser)
 
 int main(int argc, char *argv[])
 {
-    std::vector<char *> __argv;
-    __argv.push_back(argv[0]);
-    __argv.push_back((char *)"--double");
-    __argv.push_back((char *)"0.00006456");
+    std::vector<char *> dummy_argv;
+     dummy_argv.push_back(argv[0]);
+     dummy_argv.push_back((char *)"--double");
+     dummy_argv.push_back((char *)"0.00006456");
 
-    __argv.push_back((char *)"--int");
-    __argv.push_back((char *)"42");
+     dummy_argv.push_back((char *)"--int");
+     dummy_argv.push_back((char *)"42");
 
-    __argv.push_back((char *)"-s");
-    __argv.push_back((char *)"Hello");
+     dummy_argv.push_back((char *)"-s");
+     dummy_argv.push_back((char *)"Hello");
 
-    __argv.push_back((char *)"--verb");
+     dummy_argv.push_back((char *)"--verb");
 
-    __argv.push_back((char *)"--verbose");
+     dummy_argv.push_back((char *)"--verbose");
 
-    cmdlp::OptionParser parser(__argv.size() - 1, __argv.data());
+    cmdlp::OptionParser parser(dummy_argv.size() - 1, dummy_argv.data());
     parser.addOption('d', "--double", "Double value", 0.2);
     parser.addOption('i', "--int", "An integer value", 1);
     parser.addOption('s', "--string", "A string.. actually, a single word", "hello");
@@ -35,6 +35,6 @@ int main(int argc, char *argv[])
     parser.parseOptions();
 
     test_copy(parser);
-    
+
     return 0;
 }


### PR DESCRIPTION
Mostly fixing warnings, but also compilation error in tests, due to use of reserved names